### PR TITLE
Keep EventArgs immutable and selectively use MutableEventArgs

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -793,7 +793,9 @@ class Collection
         $result = $this->doRemove($query, $options);
 
         if ($this->eventManager->hasListeners(Events::postRemove)) {
-            $this->eventManager->dispatchEvent(Events::postRemove, new EventArgs($this, $result));
+            $eventArgs = new MutableEventArgs($this, $result);
+            $this->eventManager->dispatchEvent(Events::postRemove, $eventArgs);
+            $result = $eventArgs->getData();
         }
 
         return $result;
@@ -858,7 +860,9 @@ class Collection
         $result = $this->doUpdate($query, $newObj, $options);
 
         if ($this->eventManager->hasListeners(Events::postUpdate)) {
-            $this->eventManager->dispatchEvent(Events::postUpdate, new EventArgs($this, $result));
+            $eventArgs = new MutableEventArgs($this, $result);
+            $this->eventManager->dispatchEvent(Events::postUpdate, $eventArgs);
+            $result = $eventArgs->getData();
         }
 
         return $result;

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -364,7 +364,7 @@ class Collection
     public function findAndRemove(array $query, array $options = array())
     {
         if ($this->eventManager->hasListeners(Events::preFindAndRemove)) {
-            $eventArgs = new EventArgs($this, $query, $options);
+            $eventArgs = new MutableEventArgs($this, $query, $options);
             $this->eventManager->dispatchEvent(Events::preFindAndRemove, $eventArgs);
             $query = $eventArgs->getData();
             $options = $eventArgs->getOptions();
@@ -784,7 +784,7 @@ class Collection
     public function remove(array $query, array $options = array())
     {
         if ($this->eventManager->hasListeners(Events::preRemove)) {
-            $eventArgs = new EventArgs($this, $query, $options);
+            $eventArgs = new MutableEventArgs($this, $query, $options);
             $this->eventManager->dispatchEvent(Events::preRemove, $eventArgs);
             $query = $eventArgs->getData();
             $options = $eventArgs->getOptions();

--- a/lib/Doctrine/MongoDB/Event/EventArgs.php
+++ b/lib/Doctrine/MongoDB/Event/EventArgs.php
@@ -70,20 +70,4 @@ class EventArgs extends BaseEventArgs
     {
         return $this->options;
     }
-
-    /**
-     * @param $data
-     * @since 1.3
-     */
-    public function setData($data) {
-        $this->data = $data;
-    }
-
-    /**
-     * @param array $options
-     * @since 1.3
-     */
-    public function setOptions(array $options) {
-        $this->options = $options;
-    }
 }

--- a/lib/Doctrine/MongoDB/Event/MutableEventArgs.php
+++ b/lib/Doctrine/MongoDB/Event/MutableEventArgs.php
@@ -28,7 +28,9 @@ namespace Doctrine\MongoDB\Event;
 class MutableEventArgs extends EventArgs
 {
     private $changedData;
+    private $changedOptions;
     private $isDataChanged = false;
+    private $isOptionsChanged = false;
 
     /**
      * @return mixed|null
@@ -53,5 +55,33 @@ class MutableEventArgs extends EventArgs
     public function isDataChanged()
     {
         return $this->isDataChanged;
+    }
+
+    /**
+     * @since 1.3
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->isOptionsChanged ? $this->changedOptions : parent::getOptions();
+    }
+
+    /**
+     * @since 1.3
+     * @param mixed $options
+     */
+    public function setOptions(array $options)
+    {
+        $this->isOptionsChanged = parent::getOptions() !== $options;
+        $this->changedOptions = $this->isOptionsChanged ? $options : null;
+    }
+
+    /**
+     * @since 1.3
+     * @return bool
+     */
+    public function isOptionsChanged()
+    {
+        return $this->isOptionsChanged;
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
@@ -248,7 +248,7 @@ class CollectionEventsTest extends \PHPUnit_Framework_TestCase
 
         $this->expectEvents(array(
             array(Events::preRemove, new MutableEventArgs($collection, $query, $options)),
-            array(Events::postRemove, new EventArgs($collection, $result)),
+            array(Events::postRemove, new MutableEventArgs($collection, $result)),
         ));
 
         $this->assertSame($result, $collection->remove($query, $options));
@@ -281,7 +281,7 @@ class CollectionEventsTest extends \PHPUnit_Framework_TestCase
 
         $this->expectEvents(array(
             array(Events::preUpdate, new UpdateEventArgs($collection, $query, $newObj, $options)),
-            array(Events::postUpdate, new EventArgs($collection, $result)),
+            array(Events::postUpdate, new MutableEventArgs($collection, $result)),
         ));
 
         $this->assertSame($result, $collection->update($query, $newObj, $options));

--- a/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
@@ -129,7 +129,7 @@ class CollectionEventsTest extends \PHPUnit_Framework_TestCase
         $collection = $this->getMockCollection(array('doFindAndRemove' => $result));
 
         $this->expectEvents(array(
-            array(Events::preFindAndRemove, new EventArgs($collection, $query, $options)),
+            array(Events::preFindAndRemove, new MutableEventArgs($collection, $query, $options)),
             array(Events::postFindAndRemove, new MutableEventArgs($collection, $result)),
         ));
 
@@ -247,7 +247,7 @@ class CollectionEventsTest extends \PHPUnit_Framework_TestCase
         $collection = $this->getMockCollection(array('doRemove' => $result));
 
         $this->expectEvents(array(
-            array(Events::preRemove, new EventArgs($collection, $query, $options)),
+            array(Events::preRemove, new MutableEventArgs($collection, $query, $options)),
             array(Events::postRemove, new EventArgs($collection, $result)),
         ));
 

--- a/tests/Doctrine/MongoDB/Tests/Event/EventArgsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Event/EventArgsTest.php
@@ -17,15 +17,5 @@ class EventArgsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($invoker, $eventArgs->getInvoker());
         $this->assertSame($data, $eventArgs->getData());
         $this->assertSame($options, $eventArgs->getOptions());
-
-        // Check the setters
-        $data2 = array('ok' => 2);
-        $options2 = array('w' => 2);
-
-        $eventArgs->setData($data2);
-        $eventArgs->setOptions($options2);
-
-        $this->assertSame($data2, $eventArgs->getData());
-        $this->assertSame($options2, $eventArgs->getOptions());
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/Event/MutableEventArgsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Event/MutableEventArgsTest.php
@@ -18,6 +18,7 @@ class MutableEventArgsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($data, $mutableEventArgs->getData());
         $this->assertSame($options, $mutableEventArgs->getOptions());
         $this->assertFalse($mutableEventArgs->isDataChanged());
+        $this->assertFalse($mutableEventArgs->isOptionsChanged());
     }
 
     /**
@@ -61,5 +62,47 @@ class MutableEventArgsTest extends \PHPUnit_Framework_TestCase
             array('foo', 'bar'),
             array(1, 1.0),
         );
+    }
+
+    /**
+     * @dataProvider provideChangedOptions
+     */
+    public function testIsOptionsChanged($oldOptions, $newOptions)
+    {
+        $invoker = new \stdClass();
+
+        $mutableEventArgs = new MutableEventArgs($invoker, [], $oldOptions);
+
+        $this->assertFalse($mutableEventArgs->isOptionsChanged());
+        $this->assertSame($oldOptions, $mutableEventArgs->getOptions());
+
+        $mutableEventArgs->setOptions($oldOptions);
+
+        $this->assertSame($oldOptions, $mutableEventArgs->getOptions());
+        $this->assertFalse($mutableEventArgs->isOptionsChanged());
+
+        $mutableEventArgs->setOptions($newOptions);
+
+        $this->assertSame($newOptions, $mutableEventArgs->getOptions());
+        $this->assertTrue($mutableEventArgs->isOptionsChanged());
+
+        $mutableEventArgs->setOptions($newOptions);
+
+        $this->assertSame($newOptions, $mutableEventArgs->getOptions());
+        $this->assertTrue($mutableEventArgs->isOptionsChanged());
+
+        $mutableEventArgs->setOptions($oldOptions);
+
+        $this->assertSame($oldOptions, $mutableEventArgs->getOptions());
+        $this->assertFalse($mutableEventArgs->isOptionsChanged());
+    }
+
+    public function provideChangedOptions()
+    {
+        return [
+            [['foo' => 'bar'], ['foo' => 'baz']],
+            [[], ['foo' => 'bar']],
+            [['foo' => 'bar'], []],
+        ];
     }
 }


### PR DESCRIPTION
This PR implements suggested changes outlined in https://github.com/doctrine/mongodb/pull/233#issuecomment-190353463. Please read that thoroughly for an explanation of why I opted to keep the pre-event data for batchInsert, insert, and save immutable.

/cc @blockjon @alcaeus 
